### PR TITLE
fix: compatibility with fastapi 0.118.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: yesqa
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.6.4"
+    rev: "v0.13.1"
     hooks:
       - id: ruff
         args:
@@ -27,7 +27,7 @@ repos:
       - id: prettier
         additional_dependencies: [prettier@latest, prettier-plugin-toml@latest]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.11.2"
+    rev: "v1.18.2"
     hooks:
       - id: mypy
         exclude: ^tests/.*

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:f7d39a0a1fa6758100efd862d4bed2269f554c75d2d31acf911d85d36d44a402"
+content_hash = "sha256:4183dea0b9e54f7c7635e232c73b18d8cc26ec5937e5ec9e39184ad69bbf6f87"
 
 [[metadata.targets]]
 requires_python = ">=3.9"
@@ -158,7 +158,7 @@ files = [
 
 [[package]]
 name = "fastapi"
-version = "0.117.1"
+version = "0.118.0"
 requires_python = ">=3.8"
 summary = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
 groups = ["default"]
@@ -168,8 +168,8 @@ dependencies = [
     "typing-extensions>=4.8.0",
 ]
 files = [
-    {file = "fastapi-0.117.1-py3-none-any.whl", hash = "sha256:33c51a0d21cab2b9722d4e56dbb9316f3687155be6b276191790d8da03507552"},
-    {file = "fastapi-0.117.1.tar.gz", hash = "sha256:fb2d42082d22b185f904ca0ecad2e195b851030bd6c5e4c032d1c981240c631a"},
+    {file = "fastapi-0.118.0-py3-none-any.whl", hash = "sha256:705137a61e2ef71019d2445b123aa8845bd97273c395b744d5a7dfe559056855"},
+    {file = "fastapi-0.118.0.tar.gz", hash = "sha256:5e81654d98c4d2f53790a7d32d25a7353b30c81441be7d0958a26b5d761fa1c8"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "fastapi-deferred-init"
 description = "Faster FastAPI start-up time for Projects with many nested routers"
 keywords = ["fastapi", "speed", "router"]
 authors = [{ name = "Jan Vollmer", email = "jan@vllmr.dev" }]
-dependencies = ["fastapi>=0.117.1"]
+dependencies = ["fastapi>=0.118.0"]
 requires-python = ">=3.9"
 readme = "README.md"
 license = { text = "MIT" }

--- a/tests/data/gen_code_ast.py
+++ b/tests/data/gen_code_ast.py
@@ -48,7 +48,7 @@ def gen_func_def(n=1, last=False):
             defaults=[
                 ast.Call(
                     func=ast.Name(id="Depends", ctx=ast.Load()),
-                    args=[ast.Name(id=f"dependency{n-1}", ctx=ast.Load())],
+                    args=[ast.Name(id=f"dependency{n - 1}", ctx=ast.Load())],
                     keywords=[],
                 )
             ],
@@ -141,7 +141,7 @@ def gen_router(n=2, last=False, use_lib=True):
                         attr="include_router",
                         ctx=ast.Load(),
                     ),
-                    args=[ast.Name(id=f"router{n-1}", ctx=ast.Load())],
+                    args=[ast.Name(id=f"router{n - 1}", ctx=ast.Load())],
                     keywords=[],
                 )
             ),


### PR DESCRIPTION
use `request_response` from fastapi instead of starlette